### PR TITLE
fixing docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY ./config/default.js ./config/default.js
 RUN npm install --only=prod
 
 COPY --from=builder /usr/src/app/dist .
+COPY --from=builder /usr/src/app/src/infrastructure/grpc/protos/*.proto ./infrastructure/grpc/protos/
 EXPOSE 8888
 
 CMD [ "node", "./server.js" ]

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "jsonwebtoken": "^9.0.0",
     "lodash": "^4.17.21",
     "luxon": "^2.3.0",
+    "mds-log-pump": "^0.0.5",
     "mongodb": "^4.3.1",
     "pino": "^8.14.1",
     "shelljs": "^0.8.5",
@@ -76,7 +77,6 @@
     "eslint-plugin-prettier": "^4.2.1",
     "form-data": "^4.0.0",
     "jest": "^29.3.1",
-    "mds-log-pump": "^0.0.5",
     "pino-pretty": "^9.1.1",
     "prettier": "^2.5.1",
     "rimraf": "^3.0.2",
@@ -85,8 +85,5 @@
     "ts-node-dev": "^2.0.0",
     "typescript": "^4.9.3",
     "wait-on": "^7.0.1"
-  },
-  "optionalDependencies": {
-    "mds-log-pump": "^0.0.5"
   }
 }


### PR DESCRIPTION
* Adding protos to docker container
* making mds-log-pump a dependency given that the latest version of `npm ci` does not install optional dependencies anymore.