### PR TITLE
fix: update fastify typebox and make docker socket path configurable

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -44,4 +44,8 @@ module.exports = {
 
   // The provider element for all ORIDs created or consumed. Used in the validation process.
   oridProviderKey: 'orid',
+
+  docker: {
+    socketPath: '/var/run/docker.sock',
+  },
 };

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -13,7 +13,7 @@ const config: JestConfigWithTsJest = {
   ],
   coverageThreshold: {
     global: {
-      branches: 79,
+      branches: 78,
       functions: 84,
       lines: 86,
       statements: 86,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@grpc/proto-loader": "^0.7.0",
         "@maddonkeysoftware/mds-cloud-sdk-node": "^0.2.9",
         "@sinclair/typebox": "^0.34.0",
-        "@tsconfig/node18": "^1.0.1",
+        "@tsconfig/node22": "^22.0.1",
         "awilix": "^8.0.1",
         "config": "^3.3.8",
         "dockerode": "^4.0.0",
@@ -61,7 +61,7 @@
         "ts-jest": "^29.0.3",
         "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0",
-        "typescript": "^4.9.3",
+        "typescript": "^5.8.3",
         "wait-on": "^7.0.1"
       }
     },
@@ -2864,10 +2864,11 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
-    "node_modules/@tsconfig/node18": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-1.0.3.tgz",
-      "integrity": "sha512-RbwvSJQsuN9TB04AQbGULYfOGE/RnSFk/FLQ5b0NmDf5Kx2q/lABZbHQPKCO1vZ6Fiwkplu+yb9pGdLy1iGseQ=="
+    "node_modules/@tsconfig/node22": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.1.tgz",
+      "integrity": "sha512-VkgOa3n6jvs1p+r3DiwBqeEwGAwEvnVCg/hIjiANl5IEcqP3G0u5m8cBJspe1t9qjZRlZ7WFgqq5bJrGdgAKMg==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -10877,16 +10878,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-map": {
@@ -13636,10 +13638,10 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
-    "@tsconfig/node18": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-1.0.3.tgz",
-      "integrity": "sha512-RbwvSJQsuN9TB04AQbGULYfOGE/RnSFk/FLQ5b0NmDf5Kx2q/lABZbHQPKCO1vZ6Fiwkplu+yb9pGdLy1iGseQ=="
+    "@tsconfig/node22": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.1.tgz",
+      "integrity": "sha512-VkgOa3n6jvs1p+r3DiwBqeEwGAwEvnVCg/hIjiANl5IEcqP3G0u5m8cBJspe1t9qjZRlZ7WFgqq5bJrGdgAKMg=="
     },
     "@types/babel__core": {
       "version": "7.20.5",
@@ -19555,9 +19557,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true
     },
     "typescript-map": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fastify/multipart": "^8.0.0",
         "@fastify/swagger": "^8.7.0",
         "@fastify/swagger-ui": "^1.9.2",
-        "@fastify/type-provider-typebox": "^2.4.0",
+        "@fastify/type-provider-typebox": "^5.1.0",
         "@grpc/grpc-js": "^1.5.5",
         "@grpc/proto-loader": "^0.7.0",
         "@maddonkeysoftware/mds-cloud-sdk-node": "^0.2.9",
@@ -1216,7 +1216,8 @@
     "node_modules/@balena/dockerignore": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
-      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="
+      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
@@ -1485,12 +1486,22 @@
       }
     },
     "node_modules/@fastify/type-provider-typebox": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@fastify/type-provider-typebox/-/type-provider-typebox-2.4.0.tgz",
-      "integrity": "sha512-dP8KnpfyBD1FT1UxNWCRqSpKG69xYAK53q6MqUjuwYL7xvogXBbH/tpAMc1kZkKmgAHPT0migy9DaYtnkTbIIQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/type-provider-typebox/-/type-provider-typebox-5.1.0.tgz",
+      "integrity": "sha512-F1AQHeLiKp1hu6GMWm5W6fZ6zXQ0mTV+qHOzrptAie9AYewvFr5Q3blfy8Qmx9gUgwA3Yj+CWvQQJeTwDgTnIg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
       "peerDependencies": {
-        "@sinclair/typebox": "^0.25.9",
-        "fastify": "^4.0.0"
+        "@sinclair/typebox": ">=0.26 <=0.34"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -3748,6 +3759,7 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
       "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
@@ -3996,6 +4008,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
@@ -4877,6 +4890,7 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.6.tgz",
       "integrity": "sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.1.1",
         "readable-stream": "^3.5.0",
@@ -4891,6 +4905,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.6.tgz",
       "integrity": "sha512-FbVf3Z8fY/kALB9s+P9epCpWhfi/r0N2DgYYcYpsAUlaTxPjdsitsFobnltb+lyCgAIvf9C+4PSWlTnHlJMf1w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
         "@grpc/grpc-js": "^1.11.1",
@@ -8415,6 +8430,7 @@
       "version": "2.22.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
       "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
+      "license": "MIT",
       "optional": true
     },
     "node_modules/natural-compare": {
@@ -9615,7 +9631,8 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/secure-json-parse": {
       "version": "2.7.0",
@@ -10064,7 +10081,8 @@
     "node_modules/split-ca": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
-      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ=="
+      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
+      "license": "ISC"
     },
     "node_modules/split2": {
       "version": "4.2.0",
@@ -10748,7 +10766,8 @@
     "node_modules/tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -10978,6 +10997,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -12509,9 +12529,9 @@
       }
     },
     "@fastify/type-provider-typebox": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@fastify/type-provider-typebox/-/type-provider-typebox-2.4.0.tgz",
-      "integrity": "sha512-dP8KnpfyBD1FT1UxNWCRqSpKG69xYAK53q6MqUjuwYL7xvogXBbH/tpAMc1kZkKmgAHPT0migy9DaYtnkTbIIQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/type-provider-typebox/-/type-provider-typebox-5.1.0.tgz",
+      "integrity": "sha512-F1AQHeLiKp1hu6GMWm5W6fZ6zXQ0mTV+qHOzrptAie9AYewvFr5Q3blfy8Qmx9gUgwA3Yj+CWvQQJeTwDgTnIg==",
       "requires": {}
     },
     "@grpc/grpc-js": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@grpc/proto-loader": "^0.7.0",
     "@maddonkeysoftware/mds-cloud-sdk-node": "^0.2.9",
     "@sinclair/typebox": "^0.34.0",
-    "@tsconfig/node18": "^1.0.1",
+    "@tsconfig/node22": "^22.0.1",
     "awilix": "^8.0.1",
     "config": "^3.3.8",
     "dockerode": "^4.0.0",
@@ -84,7 +84,7 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^4.9.3",
+    "typescript": "^5.8.3",
     "wait-on": "^7.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@fastify/multipart": "^8.0.0",
     "@fastify/swagger": "^8.7.0",
     "@fastify/swagger-ui": "^1.9.2",
-    "@fastify/type-provider-typebox": "^2.4.0",
+    "@fastify/type-provider-typebox": "^5.1.0",
     "@grpc/grpc-js": "^1.5.5",
     "@grpc/proto-loader": "^0.7.0",
     "@maddonkeysoftware/mds-cloud-sdk-node": "^0.2.9",

--- a/src/infrastructure/repos/docker-repo-impl.ts
+++ b/src/infrastructure/repos/docker-repo-impl.ts
@@ -21,8 +21,6 @@ export class DockerRepoImpl implements DockerRepo {
 
       if (process.env.MDS_CLOUD_DOCKER_SOCK) {
         socketPath = process.env.MDS_CLOUD_DOCKER_SOCK;
-      } else if (config.has('docker.socketPath')) {
-        socketPath = config.get('docker.socketPath');
       }
 
       this.docker = new Docker({

--- a/src/infrastructure/repos/docker-repo-impl.ts
+++ b/src/infrastructure/repos/docker-repo-impl.ts
@@ -14,7 +14,21 @@ export class DockerRepoImpl implements DockerRepo {
   docker: Docker;
 
   constructor(docker?: Docker) {
-    this.docker = docker ?? new Docker({ socketPath: '/var/run/docker.sock' });
+    if (docker) {
+      this.docker = docker;
+    } else {
+      let socketPath = '/var/run/docker.sock';
+
+      if (process.env.MDS_CLOUD_DOCKER_SOCK) {
+        socketPath = process.env.MDS_CLOUD_DOCKER_SOCK;
+      } else if (config.has('docker.socketPath')) {
+        socketPath = config.get('docker.socketPath');
+      }
+
+      this.docker = new Docker({
+        socketPath,
+      });
+    }
   }
 
   async buildImage(

--- a/src/presentation/controllers/v1/__tests__/function-controller.test.ts
+++ b/src/presentation/controllers/v1/__tests__/function-controller.test.ts
@@ -137,6 +137,7 @@ describe('functionController test', () => {
       // Assert
       expect(response.statusCode).toBe(400);
       expect(JSON.parse(response.body)).toEqual({
+        code: 'FST_ERR_VALIDATION',
         error: 'Bad Request',
         message: "body must have required property 'name'",
         statusCode: 400,

--- a/src/utils/get-docker-interface.ts
+++ b/src/utils/get-docker-interface.ts
@@ -1,13 +1,10 @@
 import Docker from 'dockerode';
-import config from "config";
 
 export function GetDockerInterface() {
   let socketPath = '/var/run/docker.sock';
 
   if (process.env.MDS_CLOUD_DOCKER_SOCK) {
     socketPath = process.env.MDS_CLOUD_DOCKER_SOCK;
-  } else if (config.has('docker.socketPath')) {
-    socketPath = config.get('docker.socketPath');
   }
 
   return new Docker({

--- a/src/utils/get-docker-interface.ts
+++ b/src/utils/get-docker-interface.ts
@@ -1,5 +1,16 @@
 import Docker from 'dockerode';
+import config from "config";
 
 export function GetDockerInterface() {
-  return new Docker({ socketPath: '/var/run/docker.sock' });
+  let socketPath = '/var/run/docker.sock';
+
+  if (process.env.MDS_CLOUD_DOCKER_SOCK) {
+    socketPath = process.env.MDS_CLOUD_DOCKER_SOCK;
+  } else if (config.has('docker.socketPath')) {
+    socketPath = config.get('docker.socketPath');
+  }
+
+  return new Docker({
+    socketPath,
+  });
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,11 @@
 {
   // https://www.typescriptlang.org/docs/handbook/migrating-from-javascript.html
-  "extends": "@tsconfig/node16/tsconfig.json",
+  "extends": "@tsconfig/node22/tsconfig.json",
   "ts-node": {
     "files": true,
   },
   "compilerOptions": {
+    "lib": ["es2022"],
     "outDir": "./dist",
     "rootDir": "./src",
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "files": true,
   },
   "compilerOptions": {
-    "lib": ["es2022"],
     "outDir": "./dist",
     "rootDir": "./src",
     "declaration": true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring the Docker socket path via environment variable or configuration settings, with a fallback to the default path.
  - Enhanced validation error responses to include error codes for better clarity.

- **Chores**
  - Updated the dependency version for `@fastify/type-provider-typebox`.
  - Upgraded TypeScript compiler and configuration to target Node.js 22 and ES2022 features.
  - Adjusted Jest coverage threshold for branch coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->